### PR TITLE
s2e-arm: bugfix: pass message pointer in r0 for s2earm calls

### DIFF
--- a/guest/include/s2earm.h
+++ b/guest/include/s2earm.h
@@ -82,10 +82,11 @@ static inline void s2e_message(const char* message)
 {
 	__s2e_touch_string(message);
     __asm__ __volatile__(
+    	"MOV r0, %[msg]\n\t"
     	".WORD 0xFF100000\n\t"
         : /*no output */
     	: [msg] "r" (message)
-    	: "r0" /* we want the compiler to use r0 */
+    	: "r0"
     );
 }
 
@@ -94,11 +95,12 @@ static inline void s2e_warning(const char* message)
 {
 	__s2e_touch_string(message);
     __asm__ __volatile__(
+        	"MOV r0, %[msg]\n\t"
         	".WORD 0xFF100100\n\t"
         	".ALIGN\n"
             : /*no output */
         	: [msg] "r" (message)
-        	: "r0" /* we want the compiler to use r0 */
+        	: "r0"
     );
 }
 


### PR DESCRIPTION
The pointer to the message for the s2e_{message,warning} calls was not
set in the 'r0' register.

Setting a register as clobbered doesn't guarantee that it will be used by the compiler to set the address of a parameter in it.

I think the same fix should be done for s2e.h (the header for x86).
