### PR TITLE
bugfix: ControlFlowGraph plugin

### DIFF
--- a/qemu/configure
+++ b/qemu/configure
@@ -3823,6 +3823,7 @@ if test "$target_s2e" = "yes"; then
   S2E_DIRS="s2e s2e/Interceptor s2e/Plugins s2e/Plugins/WindowsInterceptor s2e/Configuration s2e/Signals"
   S2E_DIRS="$S2E_DIRS s2e/Plugins/DataSelectors s2e/Plugins/ExecutionTracers"
   S2E_DIRS="$S2E_DIRS s2e/Plugins/WindowsApi s2e/Plugins/Searchers"
+  S2E_DIRS="$S2E_DIRS s2e/Plugins/Avatar"
   for dir in $S2E_DIRS ; do
     mkdir -p $target_dir/$dir
   done


### PR DESCRIPTION
In the latest commit there's an added plugin in a new folder, but during build the folder is not created. 

This results in the following build error: _unable to open output file 's2e/Plugins/Avatar/ControlFlowGraph.o'_

This commit fixes this problem.
